### PR TITLE
Migrate to Java 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,13 +42,13 @@ jobs:
           KNITRO_WINDOWS_URL: ${{ secrets.KNITRO_WINDOWS_URL }}
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Build with Maven (Ubuntu)
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/snapshot-ci.yml
+++ b/.github/workflows/snapshot-ci.yml
@@ -41,11 +41,11 @@ jobs:
           KNITRO_DOWNLOAD_PASSWORD: ${{ secrets.KNITRO_DOWNLOAD_PASSWORD }}
           KNITRO_WINDOWS_URL: ${{ secrets.KNITRO_WINDOWS_URL }}
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       # Define script path variable
       - name: Set up script path
@@ -60,7 +60,7 @@ jobs:
 
       # Build powsybl-core on main branch
       - name: Checkout core sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: powsybl/powsybl-core
           ref: main
@@ -76,7 +76,7 @@ jobs:
       # The script check_integration_branch.sh is located in the workflow folder of the repository
       # It is necessary for checking out the integration branch if it exists
       - name: Checkout script
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           sparse-checkout: |
             .github
@@ -87,7 +87,7 @@ jobs:
       - name: Checking for open-loadflow snapshot branch
         run : ${{ env.SCRIPTS_PATH }}/check_integration_branch.sh "https://github.com/powsybl/powsybl-open-loadflow.git" ${{ env.CORE_VERSION }}
       - name: Checkout open-loadflow sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: powsybl/powsybl-open-loadflow
           ref: ${{ env.INTEGRATION_BRANCH }}
@@ -100,7 +100,7 @@ jobs:
         working-directory: ./powsybl-open-loadflow
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: update pom.xml with snapshot versions
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>20.2</version>
+        <version>23</version>
         <relativePath/>
     </parent>
 
@@ -42,7 +42,7 @@
     </developers>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <powsybl-core.version>6.8.1</powsybl-core.version>
         <powsybl-open-loadflow.version>1.16.0</powsybl-open-loadflow.version>
         <knitro-interfaces.version>14.2.0</knitro-interfaces.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
Planned change



**What kind of change does this PR introduce?**
OpenLFKnitro is compiled with Java 21

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
PowSyBl-OpenLFKnitro now only supports Java 21 and higher. Please check that your installed SDK is still compatible. If you are using Ubuntu 20.04 LTS and the preinstalled Maven version, you will need to upgrade your Maven version too at least up to a version 3.9.x.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->


