### PR TITLE
README: Fix CI status badges and add Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,16 @@ Optimality violation     = 0,000003
 
 
 ### Installing Knitro Java Bindings
-Knitro Java bindings require a private JAR file that must be installed locally, as it is not available on Maven Central.
-Use the following command:
+The Knitro Java bindings require a private JAR file that must be installed locally, as it is not available on Maven Central.
 
+On **Linux**, use the following command:
 ```bash
 ./mvnw install:install-file -Dfile="$KNITRODIR/examples/Java/lib/Knitro-Interfaces-2.5-KN_14.2.0.jar" -DgroupId=com.artelys -DartifactId=knitro-interfaces -Dversion=14.2.0 -Dpackaging=jar -DgeneratePom=true
+```
+
+On **Windows**, use the following command:
+```bash
+mvn install:install-file -Dfile="$env:KNITRODIR/examples/Java/lib/Knitro-Interfaces-2.5-KN_14.2.0.jar" -DgroupId="com.artelys" -DartifactId=knitro-interfaces -Dversion="14.2.0" -Dpackaging=jar -DgeneratePom=true
 ```
 
 ### Running a Load Flow with Knitro Solver

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PowSyBl Open Load Flow - Knitro Solver
 
-[![Actions Status](https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/workflows/CI/badge.svg)](https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/actions/workflows/maven.yml)
-[![Snapshot Status](https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/workflows/Snapshot%20CI/badge.svg)](https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/actions/workflows/snapshot-ci.yml)
+[![Actions Status](https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/actions/workflows/maven.yml)
+[![Snapshot Status](https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/actions/workflows/snapshot-ci.yml/badge.svg?branch=main)](https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/actions/workflows/snapshot-ci.yml)
 [![Coverage Status](https://sonarcloud.io/api/project_badges/measure?project=com.powsybl%3Apowsybl-open-loadflow-knitro-solver&metric=coverage)](https://sonarcloud.io/component_measures?id=com.powsybl%3Apowsybl-open-loadflow-knitro-solver&metric=coverage)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=com.powsybl%3Apowsybl-open-loadflow-knitro-solver&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.powsybl%3Apowsybl-open-loadflow-knitro-solver)
 [![MPL-2.0 License](https://img.shields.io/badge/license-MPL_2.0-blue.svg)](https://www.mozilla.org/en-US/MPL/2.0/)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
docs update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
incorrect badges status in readme showing last Github actions on whatever last branch the GitHub actions were run - instead of main branch. today: https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/tree/main

<img width="1047" height="135" alt="image" src="https://github.com/user-attachments/assets/3441f3a5-1992-48e4-9d28-8489ec908eee" />



**What is the new behavior (if this is a feature change)?**
README badges correctly showing status of GitHub actions for main branch:

today, see https://github.com/powsybl/powsybl-open-loadflow-knitro-solver/tree/fix-readme-badges
<img width="1040" height="161" alt="image" src="https://github.com/user-attachments/assets/73c9bc50-4078-4cf3-aabd-d6d88cb27d38" />



**Does this PR introduce a breaking change or deprecate an API?**
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
